### PR TITLE
FIX: add X-Forwarded-Proto to probes when enable_ssl_proxy true

### DIFF
--- a/charts/freescout/templates/deployment.yaml
+++ b/charts/freescout/templates/deployment.yaml
@@ -113,12 +113,22 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /login
               port: http
+              {{- if .Values.freescout.enable_ssl_proxy }}
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+              {{- end }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /login
               port: http
+              {{- if .Values.freescout.enable_ssl_proxy }}
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+              {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
- The liveness and readyness probes fail when enable_ssl_proxy is true because Freescout application redirects the request to the https.
- The liveness probe then makes the request over https which fails as the container is not listening on 443.
- If enable_ssl_proxy is not set true, then when running via an https ingress proxy some resources fail to be fetched because they are requested via http rather than https and this violates the CORS policy. An example of a request that fails is the favicon and the summernote.css file.
- This change sets a custom header on the live/ready probes when enable_ssl_proxy is true.
- This change also sets the probe path to /login to avoid a redirect for the path.