### PR TITLE
Allow additional env vars to be set in values.yaml

### DIFF
--- a/charts/freescout/Chart.yaml
+++ b/charts/freescout/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/freescout/Chart.yaml
+++ b/charts/freescout/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/freescout/templates/deployment.yaml
+++ b/charts/freescout/templates/deployment.yaml
@@ -109,6 +109,9 @@ spec:
             value: {{ .Values.freescout.enable_ssl_proxy | quote }}
           - name: SITE_URL
             value: {{ .Values.freescout.site_url | quote }}
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/freescout/templates/deployment.yaml
+++ b/charts/freescout/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
           - name: SITE_URL
             value: {{ .Values.freescout.site_url | quote }}
           {{- if .Values.extraEnv }}
-            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- toYaml .Values.extraEnv | nindent 10 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/freescout/values.yaml
+++ b/charts/freescout/values.yaml
@@ -85,6 +85,9 @@ tolerations: []
 
 affinity: {}
 
+# Add additional environment variables to the pod.
+extraEnv: []
+
 freescout:
   # Use existing secret for Administrator account. If set to false set them below directly in values
   existingSecret:


### PR DESCRIPTION
The base image supports some [custom env variables](https://github.com/tiredofit/docker-freescout?tab=readme-ov-file#environment-variables). This change allows us to easily use those.