### PR TITLE
chore: update freescout image to php8.2-1.17.137

### DIFF
--- a/charts/freescout/Chart.yaml
+++ b/charts/freescout/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "php8.2-1.17.88"
+appVersion: "php8.2-1.17.137"
 dependencies:
   - name: mariadb
     version: ~11.x

--- a/charts/freescout/values.yaml
+++ b/charts/freescout/values.yaml
@@ -25,12 +25,10 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -45,8 +43,7 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -59,8 +56,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -166,6 +162,10 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   enabled: true
 
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/mariadb
+
   architecture: standalone
 
   auth:
@@ -189,8 +189,7 @@ mariadb:
       accessMode: ReadWriteOnce
       size: 8Gi
 
-    resources:
-      {}
+    resources: {}
       # We usually recommend not to specify default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little
       # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Updates the FreeScout image to the latest version and adds MariaDB subchart configuration to address Bitnami image changes.

 This also addresses issue https://github.com/zzorica/helm-charts/issues/29
