### PR TITLE
Add Host-header to probes

### DIFF
--- a/charts/freescout/templates/deployment.yaml
+++ b/charts/freescout/templates/deployment.yaml
@@ -121,21 +121,25 @@ spec:
             httpGet:
               path: /login
               port: http
-              {{- if .Values.freescout.enable_ssl_proxy }}
               httpHeaders:
+                - name: Host
+                  value: {{ index ( .Values.freescout.site_url | split "/") "_2" }}
+                {{- if .Values.freescout.enable_ssl_proxy }}
                 - name: X-Forwarded-Proto
                   value: https
-              {{- end }}
+                {{- end }}
           readinessProbe:
             initialDelaySeconds: 20
             httpGet:
               path: /login
               port: http
-              {{- if .Values.freescout.enable_ssl_proxy }}
               httpHeaders:
+                - name: Host
+                  value: {{ index (.Values.freescout.site_url | split "/") "_2" }}
+                {{- if .Values.freescout.enable_ssl_proxy }}
                 - name: X-Forwarded-Proto
                   value: https
-              {{- end }}
+                {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Freescout added TrustHosts middleware in 1.8.211. Pod IP is unlikely to match with site_url so the probes fail.